### PR TITLE
타입오류 수정, 헤더파일 정리, 직렬화 오류 수정

### DIFF
--- a/CrazyArcade/src/Manager/NetworkManager.cpp
+++ b/CrazyArcade/src/Manager/NetworkManager.cpp
@@ -1,5 +1,5 @@
 #include "NetworkManager.h"
-#include "Network/HeaderShared.h"
+
 DEFINITION_SINGLE(NetworkManager)
 
 NetworkManager::NetworkManager()

--- a/CrazyArcade/src/Manager/NetworkManager.h
+++ b/CrazyArcade/src/Manager/NetworkManager.h
@@ -1,15 +1,38 @@
 #pragma once
 #include "Etc/stdafx.h"
+#include "Network/HeaderShared.h"
 #include "Network/MemoryStream.h"
 
+#pragma comment(lib, "ws2_32")
+
 //data size =  6 BYTE
-struct blockData{
+struct blockData {
 	char posX, posY;
 	//Block Position 기준
 	char type;			//0, softbloc, 1. hardblock, 2. tree, 3, none 4, bush	
 	char tileIndex;		//for tile image render
 	char blockIndex;	//for block image render
 	char innerItem;		//0, range 1.speed 2, bomb drop limit up 3,
+
+	void Write(OutputMemoryStream& outStream)
+	{
+		outStream.Write(posX);
+		outStream.Write(posY);
+		outStream.Write(type);
+		outStream.Write(tileIndex);
+		outStream.Write(blockIndex);
+		outStream.Write(innerItem);
+	}
+
+	void Read(InputMemoryStream& inStream)
+	{
+		inStream.Read(posX);
+		inStream.Read(posY);
+		inStream.Read(type);
+		inStream.Read(tileIndex);
+		inStream.Read(blockIndex);
+		inStream.Read(innerItem);
+	}
 };
 
 //data size =  15 * 13 * 6 + 8 = 1178 BYTE
@@ -24,24 +47,42 @@ struct InitiationData {
 
 	void Write(OutputMemoryStream& outStream)
 	{
-		outStream.Write(block);
-		outStream.Write(clientID);
-		outStream.Write(clientPosY);
-		outStream.Write(clientCharacter);
+		for (auto _block : block)
+		{
+			_block.Write(outStream);
+		}
+
+		for (int i = 0; i < 2; i++)
+			outStream.Write(clientID[i]);
+		for (int i = 0; i < 2; i++)
+			outStream.Write(clientPosX[i]);
+		for (int i = 0; i < 2; i++)
+			outStream.Write(clientPosY[i]);
+		for (int i = 0; i < 2; i++)
+			outStream.Write(clientCharacter[i]);
 	}
 
 	void Read(InputMemoryStream& inStream)
 	{
-		inStream.Read(block);
-		inStream.Read(clientID);
-		inStream.Read(clientPosY);
-		inStream.Read(clientCharacter);
+		for (auto _block : block)
+		{
+			_block.Read(inStream);
+		}
+
+		for (int i = 0; i < 2; i++)
+			inStream.Read(clientID[i]);
+		for (int i = 0; i < 2; i++)
+			inStream.Read(clientPosX[i]);
+		for (int i = 0; i < 2; i++)
+			inStream.Read(clientPosY[i]);
+		for (int i = 0; i < 2; i++)
+			inStream.Read(clientCharacter[i]);
 	}
 };
 
 //data size = 2 BYTE
 struct MoveData {
-	
+
 	char clientID;
 	char playerMoveDir;			//0, up 1, down 2, right 3, left;
 
@@ -61,7 +102,7 @@ class NetworkManager
 {
 	//Scene단에서 연결할 ip를 넘겨받아 init한다. 
 	void init(string _ip);
-	
+
 	//클라 네트워크 메니저에선 
 	void sendMoveData(char _clientID, char _playerMoveDir);
 	MoveData recvMoveData();

--- a/CrazyArcade/src/Network/SocketAddress.cpp
+++ b/CrazyArcade/src/Network/SocketAddress.cpp
@@ -6,7 +6,7 @@ string	SocketAddress::ToString() const
 #if _WIN32
 	const sockaddr_in* s = GetAsSockAddrIn();
 	char destinationBuffer[ 128 ];
-	InetNtop( s->sin_family, const_cast< in_addr* >( &s->sin_addr ), (PWSTR)destinationBuffer, sizeof( destinationBuffer ) );
+	InetNtop( s->sin_family, const_cast< in_addr* >( &s->sin_addr ), (PSTR)destinationBuffer, sizeof( destinationBuffer ) );
 	return StringUtils::Sprintf( "%s:%d",
 								destinationBuffer,
 								ntohs( s->sin_port ) );

--- a/CrazyArcade/src/Network/StringUtils.cpp
+++ b/CrazyArcade/src/Network/StringUtils.cpp
@@ -55,7 +55,7 @@ void StringUtils::Log( const char* inFormat, ... )
 #else
 	vsnprintf(temp, 4096, inFormat, args);
 #endif
-	OutputDebugString( (LPCWSTR)temp );
-	OutputDebugString( L"\n" );
+	OutputDebugString( (LPCSTR)temp );
+	OutputDebugString( "\n" );
 }
 


### PR DESCRIPTION
1. Windows관련 포인터변수중 호환되지않는 변수들을 적절하게 수정

2. Shared_Headers가 항상 가장 위에있어야 중복참조를 방지할 수 있음.

3. 잘못된 직렬화 함수사용 수정.

Primitive Type이 아닌 경우 안전한 직렬화를 위해 Assert를 호출하게 설계되어 있어, Vector에 사용자정의 클래스를 담은 경우 그 클래스의 Read Write함수를 작성하여 직렬화 해주어야합니다. 

